### PR TITLE
Spider tree description rework / Fixed hitSize / Removed hover abilities on T2+

### DIFF
--- a/content/units/spooder/elucidate.hjson
+++ b/content/units/spooder/elucidate.hjson
@@ -50,13 +50,11 @@ drag: 0.1
 speed: 0.52
 rotateSpeed: 2.4
 hovering: false
-canBoost: true
-boostMultiplier: 1.3
 drownTimeMultiplier: 2
 itemCapacity: 100
 controller: RepairAI
 mineTier: 5
-commands: [move, boost, mine, repair, rebuild, assist]
+commands: [move, mine, repair, rebuild, assist]
 mineItems: [item-ferrinite, item-demetite, item-lignite, item-obsidian]
 weapons: [
   {

--- a/content/units/spooder/elucidate.hjson
+++ b/content/units/spooder/elucidate.hjson
@@ -1,7 +1,7 @@
 type: legs
 name: Elucidate
 description: A large spiderlike unit capable of repairing damaged structures, building and mining. Equipped with a Shield Projector.
-hitSize: 16
+hitSize: 22
 health: 6750
 armor: 9
 abilities: [

--- a/content/units/spooder/elucidate.hjson
+++ b/content/units/spooder/elucidate.hjson
@@ -1,6 +1,6 @@
 type: legs
 name: Elucidate
-description: A large spiderlike unit capable of repairing damaged structures, building and mining. Equipped with a Shield Projector.
+description: Capable of building and automatically repairing damaged structures. Equipped with dual artillery and heal cannons. Projects a shield to protect nearby allied units.
 hitSize: 22
 health: 6750
 armor: 9

--- a/content/units/spooder/enlighten.hjson
+++ b/content/units/spooder/enlighten.hjson
@@ -1,10 +1,10 @@
 type: legs
-  name: Enlighten
-  description: A small legged unit capable of slowly building structures and healing. Automatically rebuilds structures and helps the player build.
+name: Enlighten
+description: A small legged unit capable of slowly building structures and healing. Automatically rebuilds structures and helps the player build.
 speed: 0.7
-  health: 410
-  armor: 4
-  flying: false
+health: 410
+armor: 4
+flying: false
 controller: BuilderAI
 commands: [move, boost, mine, repair, rebuild, assist]
 mineItems: [item-ferrinite, item-demetite, item-lignite, item-obsidian]
@@ -14,18 +14,19 @@ mineWalls: true
 mineFloor: true
 legExtension: -2.5
 buildSpeed: 0.85
-  mineSpeed: 4
-  mineTier: 1
-  legMoveSpace: 0.9
+mineSpeed: 4
+mineTier: 1
+legMoveSpace: 0.9
 isEnemy: false
 hovering: false
-  legCount: 6
+legCount: 6
 legLength: 11
 legSpeed: 0.23
 legForwardScl: 0.56
-  itemCapacity: 40
-  outlineColor: 44413c
-  weapons: [
+itemCapacity: 40
+outlineColor: 44413c
+hitSize: 12
+weapons: [
 {
   x: -8
     y: 0

--- a/content/units/spooder/enlighten.hjson
+++ b/content/units/spooder/enlighten.hjson
@@ -6,10 +6,8 @@ health: 410
 armor: 4
 flying: false
 controller: BuilderAI
-commands: [move, boost, mine, repair, rebuild, assist]
+commands: [move, mine, repair, rebuild, assist]
 mineItems: [item-ferrinite, item-demetite, item-lignite, item-obsidian]
-canBoost: true
-boostMultiplier: 1.2
 mineWalls: true
 mineFloor: true
 legExtension: -2.5

--- a/content/units/spooder/enlighten.hjson
+++ b/content/units/spooder/enlighten.hjson
@@ -1,6 +1,6 @@
 type: legs
 name: Enlighten
-description: A small legged unit capable of slowly building structures and healing. Automatically rebuilds structures and helps the player build.
+description: Capable of building and automatically repairing damaged structures. Assists other units in construction. Equipped with a healing beam and arc cannon.
 speed: 0.7
 health: 410
 armor: 4

--- a/content/units/spooder/illuminate.hjson
+++ b/content/units/spooder/illuminate.hjson
@@ -15,9 +15,7 @@ legMoveSpace: 0.9
 hovering: false
 legCount: 6
 legLength: 18
-canBoost: true
-boostMultiplier: 1.3
-commands: [move, boost, mine, repair, rebuild, assist]
+commands: [move, mine, repair, rebuild, assist]
 mineItems: [item-ferrinite, item-demetite, item-lignite, item-obsidian]
 mineWalls: true
 mineFloor: true

--- a/content/units/spooder/illuminate.hjson
+++ b/content/units/spooder/illuminate.hjson
@@ -25,6 +25,7 @@ legSpeed: 0.23
 legForwardScl: 0.56
 itemCapacity: 80
 outlineColor: 44413c
+hitSize: 15
 weapons: [
   {
     x: -9

--- a/content/units/spooder/illuminate.hjson
+++ b/content/units/spooder/illuminate.hjson
@@ -1,6 +1,6 @@
 type: legs
 name: Illuminate
-description: A medium sized legged unit capable of building structures and healing. Automatically repairs damaged structures.
+description: Capable of building and automatically repairing damaged structures. Assists other units in construction. Equipped with artillery and heal cannons.
 speed: 0.55
 health: 790
 armor: 9

--- a/content/units/spooder/luminary.hjson
+++ b/content/units/spooder/luminary.hjson
@@ -1,24 +1,25 @@
 type: legs
-  name: Luminary
-  description: A small legged unit capable of slowly building structures and healing. Automatically repairs damaged structures.
+name: Luminary
+description: A small legged unit capable of slowly building structures and healing. Automatically repairs damaged structures.
 speed: 0.6
-  health: 170
+health: 170
 controller: RepairAI
 commands: [move, repair, rebuild, assist]
-  armor: 1
-  flying: false
+armor: 1
+flying: false
 legExtension: -2.5
 buildSpeed: 0.6
-  legMoveSpace: 0.9
+legMoveSpace: 0.9
 hovering: false
 isEnemy: false
-  legCount: 6
+legCount: 6
 legLength: 8
 legSpeed: 0.23
 legForwardScl: 0.56
-  itemCapacity: 25
-  outlineColor: 44413c
-  weapons: [
+itemCapacity: 25
+outlineColor: 44413c
+hitSize: 8
+weapons: [
 {
   x: 0
     y: -3

--- a/content/units/spooder/luminary.hjson
+++ b/content/units/spooder/luminary.hjson
@@ -1,6 +1,6 @@
 type: legs
 name: Luminary
-description: A small legged unit capable of slowly building structures and healing. Automatically repairs damaged structures.
+description: Capable of building and automatically repairing damaged structures. Equipped with a small healing beam.
 speed: 0.6
 health: 170
 controller: RepairAI


### PR DESCRIPTION
Removed hover abilities because it is very janky visuals-wise and can make it seem less polished. Omit those commits if you want, it doesn't matter in my eyes.

Fun fact: I didn't know they could boost until making this PR.