### PR TITLE
make crest not braindread again

### DIFF
--- a/content/units/mech/14n-05-crest.hjson
+++ b/content/units/mech/14n-05-crest.hjson
@@ -14,6 +14,7 @@ stepSound: mechStepHeavy
 stepSoundPitch: 0.8
 stepSoundVolume: 0.45
 range: 320
+maxRange: 184
 
 abilities: [
   {
@@ -250,6 +251,7 @@ weapons: [
     chargeSound: short-laser-charge
     rotate: false
     mirror: false
+    alwaysShooting: true
     bullet: {
       type: BasicBulletType
       sprite: asthosus-star-bullet


### PR DESCRIPTION
unlobotomizes crest so that it actually uses its lazer weapons properly while not making the orbitals useless
hopefully i didnt break anything 💀 